### PR TITLE
Update Chapter 07 Integration Tests to use FluentAssertions.Web extensions

### DIFF
--- a/end/chapter07/AuthHandler/Integration.Tests/Integration.Tests.csproj
+++ b/end/chapter07/AuthHandler/Integration.Tests/Integration.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
-    <PackageReference Include="FluentAssertions" Version="8.0.0-alpha.1" />
+    <PackageReference Include="FluentAssertions.Web" Version="1.8.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />

--- a/end/chapter07/AuthHandler/Unit.Tests/Unit.Tests.csproj
+++ b/end/chapter07/AuthHandler/Unit.Tests/Unit.Tests.csproj
@@ -15,9 +15,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="7.1.0" />
     <PackageReference Include="FluentAssertions" Version="8.0.0-alpha.1" />
     <PackageReference Include="FluentAssertions.AspNetCore.Mvc" Version="4.2.0" />
-    <PackageReference Include="FluentAssertions.Web" Version="1.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.2" />


### PR DESCRIPTION
I noticed you are using [FluentAssertions.Web](https://github.com/adrianiftode/FluentAssertions.Web) for API testing, so I'm adding this PR to exemplify some of the usages in Chapter 07. FluentAsertions.Web does not only have nice extensions around the HttpResponse, but it also provides useful outputs when the tests are failing.

For example, if you would pass an invalid Bearer token, you would get the following message in the Test Detail Summary

```
 AuthenticationTests.Auth_ShouldGetPastAuthEndpointJWT
   Source: Integration.Tests.cs line 42
   Duration: 762 ms

  Message: 
Expected response to be HttpStatusCode.OK {value: 200}, but found HttpStatusCode.Unauthorized {value: 401}.

The HTTP response was:

HTTP/1.1 401 Unauthorized
WWW-Authenticate: Bearer error="invalid_token"


The originating HTTP request was:

GET http://localhost/api/Auth/testAuth HTTP 1.1
Authorization: Bearer invalid-token


  Stack Trace: 
XUnit2TestFramework.Throw(String message)
TestFrameworkProvider.Throw(String message)
DefaultAssertionStrategy.HandleFailure(String message)
AssertionScope.FailWith(Func`1 failReasonFunc)
AssertionScope.FailWith(Func`1 failReasonFunc)
AssertionScope.FailWith(String message, Object[] args)
HttpResponseMessageAssertions.Be200Ok(String because, Object[] becauseArgs)
HttpStatusCodeAssertionsExtensions.Be200Ok(HttpResponseMessageAssertions`1 parent, String because, Object[] becauseArgs)
AuthenticationTests.Auth_ShouldGetPastAuthEndpointJWT() line 50
--- End of stack trace from previous location ---
```

![image](https://github.com/user-attachments/assets/5a8a0023-9442-4d07-95e1-fd72d05f1b18)
